### PR TITLE
Add ability to configure users and fix for debian 11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ NB. this is not something you'd want to leave in there for root; a TODO is
 definitely make this module a do-nothing for root, and perhaps to allow you
 to specify a list of users who are likewise unaffected...
 
+Configure the users to moved into the namespace in /etc/unshare-users.
+One username per line.
+
 
 How it works
 ------------

--- a/src/pam_unshare.c
+++ b/src/pam_unshare.c
@@ -12,6 +12,7 @@
 #include <sched.h>
 
 #include <sys/mount.h>
+#include <sys/wait.h>
 
 #define  PAM_SM_SESSION
 #include <security/pam_modules.h>
@@ -36,6 +37,34 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, cons
     }
     _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: start", username);
 
+    FILE *fp;
+    char * line = NULL;
+    size_t len = 0;
+    ssize_t read;
+    int should_unshare = 0;
+    fp = fopen("/etc/unshare-users", "r");
+    if (fp == NULL) {
+        _pam_log(LOG_WARNING, "pam_unshare pam_sm_open_session: %s: unable to open /etc/unshare-users", username);
+	return PAM_SUCCESS;
+    }
+    while ((read = getline(&line, &len, fp)) != -1) {
+        line[strcspn(line, "\r\n")] = 0;
+        if (strcmp(line, username) == 0) {
+            should_unshare = 1;
+            break;
+        }
+    }
+
+    fclose(fp);
+    if (line) {
+        free(line);
+    }
+
+    if (should_unshare == 0) {
+        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: no need to unshare", username);
+        return PAM_SUCCESS;
+    }
+
     _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: about to unshare", username);
     int unshare_err = unshare(CLONE_NEWPID | CLONE_NEWNS);
     if (unshare_err) {
@@ -44,40 +73,17 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, cons
     }
     _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: successfully unshared", username);
 
-    if (access("/proc/cpuinfo", R_OK)) {
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: no need to umount /proc", username);
-    } else {
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: about to umount /proc", username);
-        int umount_err = umount("/proc");
-        if (umount_err) {
-            _pam_log(LOG_ERR, "pam_unshare pam_sm_open_session: %s: error umounting /proc: %s", username, strerror(errno));
-            return PAM_SESSION_ERR;
-        }
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: successfully umounted /proc", username);
-    }
-
     _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: about to kick off a subprocess", username);
     int pid = fork();
-    if (pid == 0) {
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: in subprocess, about to mount /proc", username);
-        if (mount("proc", "/proc", "proc", MS_NOSUID|MS_NOEXEC|MS_NODEV, NULL)) {
-            _pam_log(LOG_ERR, "pam_unshare pam_sm_open_session: %s: subprocess: error mounting /proc: %s", username, strerror(errno));
-            exit(1);
-        }
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: in subprocess, successfully mounted /proc", username);
-
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: in subprocess, about to busy-wait for second child", username);
-        while (kill(2, 0) == -1 && errno == ESRCH) {
-        }
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: in subprocess, second child has appeared, switching to slow-poll", username);
-
-        while (kill(2, 0) != -1 && errno != ESRCH) {
-            usleep(500000);
-        }
-        _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: in subprocess, done waiting, exiting", username);
-
+    if (pid) {
+        waitpid(pid, NULL, 0);
         exit(0);
     }
+
+    _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: in subprocess, about to mount /proc", username);
+    mount("none", "/proc", NULL, MS_PRIVATE, NULL);
+    mount("proc", "/proc", "proc", MS_NOSUID|MS_NOEXEC|MS_NODEV, NULL);
+    signal(SIGCHLD, SIG_IGN);
 
     _pam_log(LOG_DEBUG, "pam_unshare pam_sm_open_session: %s: done", username);
     return PAM_SUCCESS;
@@ -94,3 +100,4 @@ PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, con
     _pam_log(LOG_DEBUG, "pam_unshare pam_sm_close_session: %s: done", username);
     return PAM_SUCCESS;
 }
+


### PR DESCRIPTION
The process polling has been replaced with waitpid.
This is possible with a swap between the parent and
child process code. Also ignoring SIGCHLD fixes
bash spawning lots of zombie processes.